### PR TITLE
Link updates

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -38,7 +38,7 @@ It includes a core set of packages that are loaded on startup:
 
 * [`ggplot2`](https://ggplot2.tidyverse.org) implements a grammar of graphics. 
 
-* [`infer`](https://infer.tidymodels.org/) is a modern approach to statistical inference.
+* [`infer`](https://infer.tidymodels.org) is a modern approach to statistical inference.
 
 * [`parsnip`](https://parsnip.tidymodels.org) is a tidy, unified interface to creating models. 
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It includes a core set of packages that are loaded on startup:
 -   [`ggplot2`](https://ggplot2.tidyverse.org) implements a grammar of
     graphics.
 
--   [`infer`](https://infer.tidymodels.org/) is a modern approach to
+-   [`infer`](https://infer.tidymodels.org) is a modern approach to
     statistical inference.
 
 -   [`parsnip`](https://parsnip.tidymodels.org) is a tidy, unified


### PR DESCRIPTION
I had a doc-request to update a link:


From: Phil Bowsher
Priority: Low - cosmetic items, formatting, typos

Source: https://github.com/tidymodels/tidymodels | https://github.com/tidymodels/tidymodels

Request:
The "infer is a modern approach to statistical inference." link goes tohttps://infer.netlify.app/and should go  https://infer.tidymodels.org/



