### PR TITLE
Add spec from yardstick to the set of preferences

### DIFF
--- a/R/tidymodels_prefer.R
+++ b/R/tidymodels_prefer.R
@@ -27,6 +27,7 @@ tidymodels_prefer <- function(quiet = TRUE) {
       conflicted::conflict_prefer("tune",            winner = "tune",      quiet = quiet)
       conflicted::conflict_prefer("precision",       winner = "yardstick", quiet = quiet)
       conflicted::conflict_prefer("recall",          winner = "yardstick", quiet = quiet)
+      conflicted::conflict_prefer("spec",            winner = "yardstick", quiet = quiet)
     },
     type = "message")
   if (!quiet) {


### PR DESCRIPTION
`yardstick::spec()` conflicts with `readr::spec()`.  So this adds `spec()` to the preferred functions  in `tidymodels_prefer()`.