### PR TITLE
remove README.md from .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,7 +3,6 @@
 travis.yml
 codecov.yml
 README.Rmd
-README.md
 README.html
 ^docs$
 ^pkgdown$


### PR DESCRIPTION
This PR removes `README.md` from `.Rbuildignore` making it so it will show up on CRAN and within the Package Manager UI.