### PR TITLE
link help pages for `tidymodels_prefer()` and `tidymodels_conflicts()`

### DIFF
--- a/R/conflicts.R
+++ b/R/conflicts.R
@@ -8,6 +8,10 @@
 #' make the base equivalents generic, so shouldn't negatively affect any
 #' existing code.
 #'
+#' To manage conflicts, you can use the conflicted package. To prefer tidymodels
+#' functions over other functions, use [tidymodels_prefer()].
+#'
+#' @seealso [tidymodels_prefer()]
 #' @export
 #' @examples
 #' tidymodels_conflicts()

--- a/R/tidymodels_prefer.R
+++ b/R/tidymodels_prefer.R
@@ -11,6 +11,7 @@
 #' resolution during the R session.
 #'
 #' @param quiet If `TRUE`, all output will be suppressed
+#' @seealso [tidymodels_conflicts()]
 #' @export
 #' @examples
 #' tidymodels_prefer(quiet = FALSE)

--- a/man/tidymodels_conflicts.Rd
+++ b/man/tidymodels_conflicts.Rd
@@ -15,7 +15,13 @@ There are four conflicts that are deliberately ignored: \code{intersect},
 \code{union}, \code{setequal}, and \code{setdiff} from dplyr. These functions
 make the base equivalents generic, so shouldn't negatively affect any
 existing code.
+
+To manage conflicts, you can use the conflicted package. To prefer tidymodels
+functions over other functions, use \code{\link[=tidymodels_prefer]{tidymodels_prefer()}}.
 }
 \examples{
 tidymodels_conflicts()
+}
+\seealso{
+\code{\link[=tidymodels_prefer]{tidymodels_prefer()}}
 }

--- a/man/tidymodels_prefer.Rd
+++ b/man/tidymodels_prefer.Rd
@@ -24,3 +24,6 @@ resolution during the R session.
 \examples{
 tidymodels_prefer(quiet = FALSE)
 }
+\seealso{
+\code{\link[=tidymodels_conflicts]{tidymodels_conflicts()}}
+}


### PR DESCRIPTION
This PR adds links between `tidymodels_conflicts()` and `tidymodels_prefer()` in the help pages.